### PR TITLE
This should fix the Travis runs that are currently failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,14 @@ language: php
 
 # Declare versions of PHP to use. Use one decimal max.
 php:
+  # aliased to a recent 7.3.x version
+  - "7.3"
+  # aliased to a recent 7.2.x version
+  - "7.2"
   # aliased to a recent 7.1.x version
   - "7.1"
   # aliased to a recent 5.6.x version
   - "5.6"
-  # aliased to a recent 5.3.x version
-  - "5.3"
-  # Current $required_php_version for WordPress: 5.2.4
-  # "5.2"
 
 # Declare which versions of WordPress to test against.
 # Also declare whether or not to test in Multisite.
@@ -30,17 +30,18 @@ env:
   # @link https://github.com/WordPress/WordPress
   # WP_VERSION=master WP_MULTISITE=0
   - WP_VERSION=master WP_MULTISITE=1
-  # WordPress 4.7
-  # @link https://github.com/WordPress/WordPress/tree/4.7-branch
-  # WP_VERSION=4.7 WP_MULTISITE=0
-  - WP_VERSION=4.7 WP_MULTISITE=1
+  # WordPress 5.2
+  # @link https://github.com/WordPress/WordPress/tree/5.2-branch
+  # WP_VERSION=5.2 WP_MULTISITE=0
+  - WP_VERSION=5.2 WP_MULTISITE=1
 
 # Declare "future" releases to be acceptable failures.
 # @link https://buddypress.trac.wordpress.org/ticket/5620
 # @link http://docs.travis-ci.com/user/build-configuration/
 matrix:
   allow_failures:
-    - php: "7.1"
+    - php: "7.3"
+    - php: "7.2"
     - php: "5.6"
     - env: WP_VERSION=master WP_MULTISITE=1
   fast_finish: true
@@ -79,11 +80,9 @@ before_script:
   - git clone https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git wordpress-coding-standards
   # Hop into CodeSniffer directory.
   - cd php-codesniffer
-  # Checkout pre 3.x version
-  - git checkout tags/2.9.0
   # Set install path for WordPress Coding Standards.
   # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-  - scripts/phpcs --config-set installed_paths ../wordpress-coding-standards
+  - bin/phpcs --config-set installed_paths ../wordpress-coding-standards
   # Hop into themes directory.
   - cd $theme_dir
   # After CodeSniffer install you should refresh your path.
@@ -108,7 +107,7 @@ script:
   # --extensions: Only sniff PHP files.
   # --report=source: Return summary table
   # --report=full: Returns verbose list of problems by test and line
-  - $WP_DEVELOP_DIR/php-codesniffer/scripts/phpcs -p -s -v -n . --standard=./codesniffer.ruleset.xml --extensions=php --report=source --report=full
+  - $WP_DEVELOP_DIR/php-codesniffer/bin/phpcs -p -s -v -n . --standard=./codesniffer.mitlib.xml --extensions=php --report=source --report=full
   # phpunit
 
 # Receive notifications for build results.

--- a/codesniffer.mitlib.xml
+++ b/codesniffer.mitlib.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Theme Coding Standards">
+	<!-- See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/WordPress-Core/ruleset.xml -->
+
+	<!-- Set a description for this ruleset. -->
+	<description>A custom set of code standard rules to check for WordPress plugins.</description>
+
+	<!-- Include the WordPress ruleset, with exclusions. -->
+	<rule ref="WordPress">
+		<!-- Exclude non-security sniffs -->
+		<exclude name="Generic" />
+		<exclude name="PEAR" />
+		<exclude name="PSR2" />
+		<exclude name="Squiz" />
+		<exclude name="WordPress.Arrays" />
+		<exclude name="WordPress.Classes" />
+		<exclude name="WordPress.CodeAnalysis" />
+		<exclude name="WordPress.DB" />
+		<exclude name="WordPress.Files" />
+		<exclude name="WordPress.NamingConventions" />
+		<exclude name="WordPress.PHP" />
+		<exclude name="WordPress.Utils" />
+		<exclude name="WordPress.WP" />
+		<exclude name="WordPress.WhiteSpace" />
+	</rule>
+</ruleset>


### PR DESCRIPTION
This resolves the recent failures that we've seen with Travis runs, where PHPCS fails (rather than reports sniff violations) because it is finding references to outdated sniffs.

The solution has been to:
- Ditch support for PHP 5.3 (as our new server is launching soon)
- Bump the supported PHP versions to include 7.2 and 7.3
- Bump the WP version to 5.2
- Update PHPCS to the current release (rather than being pinned to 2.9.0 because of PHP 5.3 support)
- Update the codesniffer exclusions to rule out all but the security-related sniffs (aesthetics and other checks will be done by Codeclimate)