### PR TITLE
Updates Travis / PHPCS to current repo standards

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,9 +4,7 @@ engines:
     enabled: true
     config:
       languages:
-      - ruby
       - javascript
-      - python
       - php
   fixme:
     enabled: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Status
+_Use labels (`review needed`, `in progress`, or `paused`) to declare status_
+
+#### What does this PR do?
+A few sentences describing the overall goals of the pull request's commits.
+Why are we making these changes? Is there more work to be done to fully
+achieve these goals?
+
+#### Helpful background context (if appropriate)
+
+#### How can a reviewer manually see the effects of these changes?
+
+#### What are the relevant tickets?
+- https://mitlibraries.atlassian.net/browse/NTI-
+
+#### Screenshots (if appropriate)
+
+#### Todo:
+- [ ] Documentation
+- [ ] Stakeholder approval
+
+#### Requires new or updated plugins, themes, or libraries?
+YES | NO
+
+#### Requires change to deploy process?
+YES | NO

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,39 +12,27 @@ dist: precise
 # @link http://about.travis-ci.org/docs/user/languages/php/
 language: php
 
-# Declare versions of PHP to use. Use one decimal max.
-php:
-  # aliased to a recent 7.3.x version
-  - "7.3"
-  # aliased to a recent 7.2.x version
-  - "7.2"
-  # aliased to a recent 7.1.x version
-  - "7.1"
-  # aliased to a recent 5.6.x version
-  - "5.6"
-
-# Declare which versions of WordPress to test against.
-# Also declare whether or not to test in Multisite.
-env:
-  # Trunk
-  # @link https://github.com/WordPress/WordPress
-  # WP_VERSION=master WP_MULTISITE=0
-  - WP_VERSION=master WP_MULTISITE=1
-  # WordPress 5.2
-  # @link https://github.com/WordPress/WordPress/tree/5.2-branch
-  # WP_VERSION=5.2 WP_MULTISITE=0
-  - WP_VERSION=5.2 WP_MULTISITE=1
-
 # Declare "future" releases to be acceptable failures.
 # @link https://buddypress.trac.wordpress.org/ticket/5620
 # @link http://docs.travis-ci.com/user/build-configuration/
 matrix:
+  fast_finish: true
+
+  include:
+    # Declare versions of PHP to use. Use one decimal max.
+    # We sniff the current and +1 release of PHP, and just run syntax checking
+    # for others.
+    - php: 'nightly'
+    - php: '7.3'
+    - php: '7.2'
+      env: PHPCS_BRANCH=master PHPCS_SCRIPT=bin SNIFF=1
+    - php: '7.1'
+      env: PHPCS_BRANCH=master PHPCS_SCRIPT=bin SNIFF=1
+
   allow_failures:
+    - php: "nightly"
     - php: "7.3"
     - php: "7.2"
-    - php: "5.6"
-    - env: WP_VERSION=master WP_MULTISITE=1
-  fast_finish: true
 
 # Use this to prepare the system to install prerequisites or dependencies.
 # e.g. sudo apt-get update.
@@ -55,47 +43,29 @@ matrix:
 # e.g. copy database configurations, environment variables, etc.
 # Failures in this section will result in build status 'errored'.
 before_script:
-  # Set up WordPress installation.
-  - export WP_DEVELOP_DIR=/tmp/wordpress/
-  - mkdir -p $WP_DEVELOP_DIR
-  # Use the Git mirror of WordPress.
-  - git clone --depth=1 --branch="$WP_VERSION" git://develop.git.wordpress.org/ $WP_DEVELOP_DIR
-  # Set up theme information.
-  - theme_slug=$(basename $(pwd))
-  - theme_dir=$WP_DEVELOP_DIR/src/wp-content/themes/$theme_slug
-  - cd ..
-  - mv $theme_slug $theme_dir
-  # Set up WordPress configuration.
-  - cd $WP_DEVELOP_DIR
-  - echo $WP_DEVELOP_DIR
-  - cp wp-tests-config-sample.php wp-tests-config.php
-  - sed -i "s/youremptytestdbnamehere/wordpress_test/" wp-tests-config.php
-  - sed -i "s/yourusernamehere/root/" wp-tests-config.php
-  - sed -i "s/yourpasswordhere//" wp-tests-config.php
-  # Create WordPress database.
-  - mysql -e 'CREATE DATABASE wordpress_test;' -uroot
-  # Install CodeSniffer for WordPress Coding Standards checks.
-  - git clone https://github.com/squizlabs/PHP_CodeSniffer.git php-codesniffer
-  # Install WordPress Coding Standards.
-  - git clone https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git wordpress-coding-standards
-  # Hop into CodeSniffer directory.
-  - cd php-codesniffer
+  # Define PHP_CodeSniffer install
+  - export PHPCS_DIR=/tmp/phpcs
+  # Define WordPress Coding Standards
+  - export WPCS_DIR=/tmp/wpcs
+  - export WPCS_BRANCH=master
+  # Install WordPress Coding Standards (master branch, not develop).
+  - if [[ "$SNIFF" == "1" ]]; then git clone -b $WPCS_BRANCH https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
+  # Install CodeSniffer for WordPress Coding Standards checks (pre 3.x version).
+  - if [[ "$SNIFF" == "1" ]]; then git clone -b $PHPCS_BRANCH https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
+  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/$PHPCS_SCRIPT/phpcs --version; fi
   # Set install path for WordPress Coding Standards.
   # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-  - bin/phpcs --config-set installed_paths ../wordpress-coding-standards
-  # Hop into themes directory.
-  - cd $theme_dir
+  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/$PHPCS_SCRIPT/phpcs --config-set installed_paths $WPCS_DIR; fi
   # After CodeSniffer install you should refresh your path.
   - phpenv rehash
-  # Install actual unit tests.
-  # bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION 
 
 # Run test script commands.
 # Default is specific to project language.
 # All commands must exit with code 0 on success. Anything else is considered failure.
 script:
-  # Search for PHP syntax errors.
-  - find . \( -name '*.php' \) -exec php -lf {} \;
+  # Search for PHP syntax errors outside the libs directory
+  # @link http://stackoverflow.com/questions/4210042/exclude-directory-from-find-command
+  - find . -path ./libs -prune -o \( -name '*.php' \) -exec php -lf {} \;
   # WordPress Coding Standards
   # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
   # @link http://pear.php.net/package/PHP_CodeSniffer/
@@ -107,10 +77,9 @@ script:
   # --extensions: Only sniff PHP files.
   # --report=source: Return summary table
   # --report=full: Returns verbose list of problems by test and line
-  - $WP_DEVELOP_DIR/php-codesniffer/bin/phpcs -p -s -v -n . --standard=./codesniffer.mitlib.xml --extensions=php --report=source --report=full
-  # phpunit
+  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/$PHPCS_SCRIPT/phpcs -p -s -v -n . --standard=./codesniffer.mitlib.xml --extensions=php --report=source --report=full; fi
 
 # Receive notifications for build results.
 # @link http://docs.travis-ci.com/user/notifications/#Email-notifications
 notifications:
-    email: false
+  email: false


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This updates the PHPCS configuration to match that used by our themes:
- Using the current release of PHPCS (when we supported PHP 5.3 we had to use an older version)
- Testing against current PHP version (7.1 - 7.3, allowing failures for 7.2 and 7.3)
- Checking only security-related problems, leaving other tests to CodeClimate (which does better at testing only changed lines)

Beyond the above changes, this PR also adds this PR template message, as well as edits the CodeClimate list of languages to only be PHP and Javascript. These are standard configurations in other repositories, but were missed here somehow.

#### Helpful background context (if appropriate)
The reference implementation for themes is the Parent theme - https://github.com/mitlibraries/mitlibraries-parent

#### How can a reviewer manually see the effects of these changes?
Check the results of the Travis review below. Ideally it will pass (which is the case in this repo). It should at least return a failed result (successfully ending, and flagging problems if they exist) rather than erroring.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-529

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
